### PR TITLE
chore: include tags in the CI to cover the release.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "*"
     paths-ignore:
       - "**/*.md"
       - "LICENSE"


### PR DESCRIPTION
Actions in https://github.com/jcchavezs/coraza-http-wasm/pull/11 were correct but action wasn't triggered on tag push.